### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Aka, CAAnimation + Closure or CAAnimation + Block.
 ![demo-animating](https://raw.githubusercontent.com/honghaoz/Swift-CAAnimation-Closure/master/Demo/demo-animating.gif)
 
 # Installation
-####CocoaPods
+#### CocoaPods
 
 ```ruby
 use_frameworks!
@@ -21,7 +21,7 @@ use_frameworks!
 pod 'Swift-CAAnimation-Closure', '~> 1.0'
 ```
 
-####Manually
+#### Manually
 
 Just add `CAAnimation+Closure.swift` file into your project.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
